### PR TITLE
Fix getting profile id

### DIFF
--- a/lib/passport-asana/strategy.js
+++ b/lib/passport-asana/strategy.js
@@ -82,7 +82,7 @@ Strategy.prototype.userProfile = function(accessToken, done) {
       var json = JSON.parse(body).data;
 
       var profile = { provider: 'Asana' };
-      profile.id = json.id;
+      profile.id = json.id || json.gid;
       profile.displayName = json.name;
       profile.emails = [{ value: json.email }];
 


### PR DESCRIPTION
Raw is without id field now:
'{"data":{"gid":"123","email":"user@asana.com","name":"user name"}}'

https://asana.com/developers/news/a-reminder-about-integer-id-deprecation